### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ modified_binary = binary.write_struct(new_symbol_table, binary.symtab.address, v
 modified_binary = modified_binary.insert_load_dylib_cmd("/System/Frameworks/UIKit.framework/UIKit")
 
 # Write the modified binary to a file
-MachoBinary.write_binary(Path(__file__).parent / "modified_binary")
+modified_binary.write_binary(Path(__file__).parent / "modified_binary")
 ```
 
 `MachoBinary` provides several functions to faciliate binary modifications.


### PR DESCRIPTION
### Summary
This PR fixes the example to use the correct variable.

### Description
In the section [Modifying Mach-O's](https://github.com/datatheorem/strongarm#modifying-mach-os), you can find an example that modifies an existing binary.

```python
from pathlib import Path
from strongarm.macho import MachoParser, MachoBinary
from strongarm.macho.macho_definitions import MachoSymtabCommand

macho_parser = MachoParser(Path("~/Documents/MyApp.app/MyApp"))
# Overwrite a structure
binary: MachoBinary = macho_parser.get_arm64_slice()
new_symbol_table = MachoSymtabCommand()
new_symbol_table.nsyms = 0
modified_binary = binary.write_struct(new_symbol_table, binary.symtab.address, virtual=True)

# Add a load command
modified_binary = modified_binary.insert_load_dylib_cmd("/System/Frameworks/UIKit.framework/UIKit")

# Write the modified binary to a file
MachoBinary.write_binary(Path(__file__).parent / "modified_binary")
```

However, it produces an error in the final line:
```
TypeError: MachoBinary.write_binary() missing 1 required positional argument: 'path'
```

It is because `write_binary` isn't a static function.

### Deployment
- [x] No Dependencies

Closes: #N/A